### PR TITLE
Added: Linux Steam Stardew Manifest IDs, Beta Branches of Stardew, macOS Builds

### DIFF
--- a/contrib/version_aliases.yaml
+++ b/contrib/version_aliases.yaml
@@ -6,24 +6,46 @@ Stardew Valley:
     - Name: 1.6.12
       GOG:
         - 1.6.12.24312.8292123749
+      Steam:
+        - 7276192310056789702
     - Name: 1.6.13
       GOG:
         - 1.6.13.24313.8303763006
+      Steam:
+        - 1289391404978285152 
     - Name: 1.6.14
       GOG:
         - 1.6.14.24317.8331381720
       Steam:
         - 1364246008775303529
     # This version only exists in some repos, and was only the latest version for about 2 days, looks like the next version removed a file that
-    # was no longer needed
+    # was no longer needed. (accidentally included library from macOS build on Windows)
     - Name: 1.6.15 (unused)
       GOG:
         - 1.6.15.24355.8684237877
+      Steam:
+        - 6757974702735282197
     - Name: 1.6.15
       GOG:
         - 1.6.15.24357.8705766150
       Steam:
         - 4278718763097142923
+  Linux:
+    - Name: 1.6.12
+      Steam:
+        - 354045480657147132
+    - Name: 1.6.13
+      Steam:
+        - 8095929248374658484
+    - Name: 1.6.14
+      Steam:
+        - 5957588574415759106
+    - Name: 1.6.15 (unused)
+      Steam:
+        - 3983657410305550278
+    - Name: 1.6.15
+      Steam:
+        - 6005910083361727734
 Cyberpunk 2077:
   Windows:
     - Name: 1.63_Hotfix

--- a/contrib/version_aliases.yaml
+++ b/contrib/version_aliases.yaml
@@ -15,13 +15,13 @@ Stardew Valley:
     - Name: 1.6.12
       GOG:
         - 1.6.12.24312.8292123749
-      Steam:
-        - 7276192310056789702
+      # Steam:
+      #  - 7276192310056789702 # for reference only, we didn't index this.
     - Name: 1.6.13
       GOG:
-        - 1.6.13.24313.8303763006
-      Steam:
-        - 1289391404978285152 
+       - 1.6.13.24313.8303763006
+      # Steam:
+      #  - 1289391404978285152 # for reference only, we didn't index this.
     - Name: 1.6.14
       GOG:
         - 1.6.14.24317.8331381720
@@ -32,8 +32,8 @@ Stardew Valley:
     - Name: 1.6.15 (unused)
       GOG:
         - 1.6.15.24355.8684237877
-      Steam:
-        - 6757974702735282197
+      # Steam:
+      #  - 6757974702735282197 # for reference only, we didn't index this.
     - Name: 1.6.15
       GOG:
         - 1.6.15.24357.8705766150
@@ -66,19 +66,19 @@ Stardew Valley:
       Steam:
         - 4264972535478467767
     - Name: 1.6.12
-      Steam:
-        - 354045480657147132
+      # Steam:
+      #  - 354045480657147132 # for reference only, we didn't index this
     - Name: 1.6.13
-      Steam:
-        - 8095929248374658484
+      # Steam:
+      #  - 8095929248374658484 # for reference only, we didn't index this
     - Name: 1.6.14
       Steam:
         - 5957588574415759106
     # Accidentally included library from MacOS build on other platforms
     # and so was pulled.
     - Name: 1.6.15 (unused)
-      Steam:
-        - 3983657410305550278
+      # Steam:
+      #  - 3983657410305550278 # for reference only, we didn't index this.
     - Name: 1.6.15
       Steam:
         - 6005910083361727734

--- a/contrib/version_aliases.yaml
+++ b/contrib/version_aliases.yaml
@@ -28,7 +28,7 @@ Stardew Valley:
       Steam:
         - 1364246008775303529
     # This version only exists in some repos, and was only the latest version for about 2 days, looks like the next version removed a file that
-    # was no longer needed. (accidentally included library from macOS build on Windows)
+    # was no longer needed. (accidentally included library from MacOS build on other platforms)
     - Name: 1.6.15 (unused)
       GOG:
         - 1.6.15.24355.8684237877
@@ -39,7 +39,7 @@ Stardew Valley:
         - 1.6.15.24357.8705766150
       Steam:
         - 4278718763097142923
-  macOS:
+  MacOS:
     - Name: compatibility # betas -> compatibility
       Steam:
         - 8537850295833278518
@@ -74,6 +74,8 @@ Stardew Valley:
     - Name: 1.6.14
       Steam:
         - 5957588574415759106
+    # Accidentally included library from MacOS build on other platforms
+    # and so was pulled.
     - Name: 1.6.15 (unused)
       Steam:
         - 3983657410305550278

--- a/contrib/version_aliases.yaml
+++ b/contrib/version_aliases.yaml
@@ -3,6 +3,15 @@
 # for example)
 Stardew Valley:
   Windows:
+    - Name: compatibility # betas -> compatibility
+      Steam:
+        - 4848991934266309406
+    - Name: 1.5.6 # betas -> legacy_1.5.6
+      Steam:
+        - 5609262347030774375
+    - Name: 1.6.8
+      Steam:
+        - 1777024427851858279
     - Name: 1.6.12
       GOG:
         - 1.6.12.24312.8292123749
@@ -30,7 +39,32 @@ Stardew Valley:
         - 1.6.15.24357.8705766150
       Steam:
         - 4278718763097142923
+  macOS:
+    - Name: compatibility # betas -> compatibility
+      Steam:
+        - 8537850295833278518
+    - Name: 1.5.6 # betas -> legacy_1.5.6
+      Steam:
+        - 7794216274031597899
+    - Name: 1.6.8
+      Steam:
+        - 2235726939199153098
+    - Name: 1.6.14
+      Steam:
+        - 4280144724332332812
+    - Name: 1.6.15
+      Steam:
+        - 2618652301291810021
   Linux:
+    - Name: compatibility # betas -> compatibility
+      Steam:
+        - 8332166493523218127
+    - Name: 1.5.6 # betas -> legacy_1.5.6
+      Steam:
+        - 5898757968212855302
+    - Name: 1.6.8
+      Steam:
+        - 4264972535478467767
     - Name: 1.6.12
       Steam:
         - 354045480657147132
@@ -78,4 +112,3 @@ Cyberpunk 2077:
         - 2.21
       Steam:
         - 8420445566849588826
-


### PR DESCRIPTION
Also re-added the Manifest IDs for the other Windows builds, just commented out since we didn't index them.

Fixes:

- https://github.com/Nexus-Mods/NexusMods.App/issues/2657

Before PR:

![image](https://github.com/user-attachments/assets/099ef1dd-7ed3-4afa-b3fe-5ff37a909339)

(Latest Linux Stardew)

Post PR: 

![image](https://github.com/user-attachments/assets/c636a8d7-e63a-4340-853a-e46145befe06)

I verified a bunch of the Linux and Windows builds (by actually installing them), but did not verify the macOS ones.
They should be correct however, as I've cross referenced with `413150.json`.